### PR TITLE
Allow scheduled conference editors to view plugins

### DIFF
--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -209,6 +209,7 @@ class Role extends Model
                     'Payment:update',
                     'Payment:delete',
                     'Permission:viewAny',
+                    'Plugin:viewAny',
                     'Proceeding:create',
                     'Proceeding:delete',
                     'Proceeding:update',

--- a/tests/Unit/RoleDefaultPermissionsTest.php
+++ b/tests/Unit/RoleDefaultPermissionsTest.php
@@ -15,4 +15,15 @@ class RoleDefaultPermissionsTest extends TestCase
             Role::getPermissionsForRole(UserRole::ScheduledConferenceEditor->value)
         );
     }
+
+    public function test_scheduled_conference_editor_can_view_but_not_manage_plugins(): void
+    {
+        $permissions = Role::getPermissionsForRole(UserRole::ScheduledConferenceEditor->value);
+
+        $this->assertContains('Plugin:viewAny', $permissions);
+        $this->assertNotContains('Plugin:install', $permissions);
+        $this->assertNotContains('PluginGallery:install', $permissions);
+        $this->assertNotContains('Plugin:update', $permissions);
+        $this->assertNotContains('Plugin:delete', $permissions);
+    }
 }


### PR DESCRIPTION
## Summary
- grant Scheduled Conference Editors `Plugin:viewAny`
- retain the restrictions on installing, uninstalling, and toggling plugins
- cover the permission boundary with a unit test

## Verification
- `vendor/bin/pint --test app/Models/Role.php tests/Unit/RoleDefaultPermissionsTest.php`
- `vendor/bin/phpunit tests/Unit/RoleDefaultPermissionsTest.php`